### PR TITLE
Propagar icono principal a formularios secundarios

### DIFF
--- a/main.py
+++ b/main.py
@@ -337,7 +337,8 @@ ventana.geometry("500x580")
 ventana.resizable(False, False)
 
 try:
-    ventana.iconphoto(False, tk.PhotoImage(file="icono_app.png"))
+    # Establecer el icono como predeterminado para todas las ventanas
+    ventana.iconphoto(True, tk.PhotoImage(file="icono_app.png"))
 except:
     pass
 


### PR DESCRIPTION
## Resumen
- Establecer el icono como predeterminado en `main.py` para que lo hereden todas las ventanas secundarias.

## Pruebas
- `python -m py_compile SansebasSms_Sync/main.py SansebasSms_Sync/GestionUsuarios.py SansebasSms_Sync/GestionMensajes.py`

------
https://chatgpt.com/codex/tasks/task_b_68aaffa20d988327a6ce9e36073ba443