### PR TITLE
Evitar múltiples ventanas de gestión

### DIFF
--- a/GestionMensajes.py
+++ b/GestionMensajes.py
@@ -15,6 +15,9 @@ from firebase_admin import firestore
 
 nombre_cache: Dict[str, str] = {}
 
+# Ventana principal de gestión de mensajes (singleton)
+ventana_mensajes = None
+
 
 def sanitize_filename(s: str) -> str:
     return re.sub(r'[\\/*?:"<>|]+', " ", s).strip()
@@ -56,9 +59,24 @@ def fetch_nombre(uid: str, db: firestore.Client) -> str:
 
 
 def abrir_gestion_mensajes(db: firestore.Client) -> None:
-    ventana = tk.Toplevel()
+    """Abre la ventana de gestión de mensajes evitando duplicados."""
+    global ventana_mensajes
+    if ventana_mensajes and ventana_mensajes.winfo_exists():
+        ventana_mensajes.lift()
+        ventana_mensajes.focus_force()
+        return
+
+    ventana_mensajes = tk.Toplevel()
+    ventana = ventana_mensajes
     ventana.title("Gestión de Mensajes")
     ventana.geometry("900x500")
+
+    def on_close():
+        global ventana_mensajes
+        ventana_mensajes = None
+        ventana.destroy()
+
+    ventana.protocol("WM_DELETE_WINDOW", on_close)
 
     datos_tabla = []
 

--- a/GestionUsuarios.py
+++ b/GestionUsuarios.py
@@ -14,6 +14,9 @@ from concurrent.futures import ThreadPoolExecutor
 import time
 
 
+# Ventana principal de gestión de usuarios (singleton)
+ventana_usuarios = None
+
 # Funciones auxiliares de normalización
 def s(x):
     return "" if x is None else str(x)
@@ -162,9 +165,24 @@ def cargar_datos_ajustados(dnis: Iterable[str], min_alta: date) -> Dict[str, Dic
     return final
 
 def abrir_gestion_usuarios(db):
-    ventana = tk.Toplevel()
+    """Abre la ventana de gestión de usuarios evitando duplicados."""
+    global ventana_usuarios
+    if ventana_usuarios and ventana_usuarios.winfo_exists():
+        ventana_usuarios.lift()
+        ventana_usuarios.focus_force()
+        return
+
+    ventana_usuarios = tk.Toplevel()
+    ventana = ventana_usuarios
     ventana.title("👥 Gestión de Usuarios")
     ventana.geometry("1400x600")
+
+    def on_close():
+        global ventana_usuarios
+        ventana_usuarios = None
+        ventana.destroy()
+
+    ventana.protocol("WM_DELETE_WINDOW", on_close)
 
     columnas = ["Dni", "Nombre", "Telefono", "correo", "Puesto", "Turno", "Cultivo",
                 "Mensaje", "Seleccionable", "Valor", "Alta", "UltimoDia", "TotalDia", "TotalHoras", "Baja", "Codigo"]


### PR DESCRIPTION
## Summary
- Evitar aperturas duplicadas en la gestión de usuarios mediante una ventana única reutilizable.
- Añadir control equivalente en la gestión de mensajes con callback de cierre que reinicia el estado.

## Testing
- `python -m py_compile GestionUsuarios.py GestionMensajes.py`


------
https://chatgpt.com/codex/tasks/task_b_68ab06ea8e64832784b35bacd15e0313