### PR TITLE
Prompt for missing Firebase credentials

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,6 +60,23 @@ archivo_notificados = "notificados.json"
 
 # Inicializar Firebase
 try:
+    if not os.path.exists(credenciales_dinamicas["ruta"]):
+        root = tk.Tk()
+        root.withdraw()
+        nueva_ruta = filedialog.askopenfilename(
+            title="Selecciona archivo de credenciales",
+            filetypes=[("Archivos JSON", "*.json")]
+        )
+        if not nueva_ruta:
+            messagebox.showinfo(
+                "Credenciales",
+                "No se seleccionó archivo de credenciales. La aplicación se cerrará."
+            )
+            root.destroy()
+            exit()
+        credenciales_dinamicas["ruta"] = nueva_ruta
+        root.destroy()
+
     with open(credenciales_dinamicas["ruta"], "r") as f:
         data = json.load(f)
         project_info["id"] = data.get("project_id")


### PR DESCRIPTION
## Summary
- Check for missing Firebase credentials and prompt user to select a JSON file.
- Update credential path dynamically or exit with an info message when no file is chosen.

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6a69444d0832782ccd261a47b407a