### PR TITLE
Expand message management fields and validation

### DIFF
--- a/GenerarMensajes.py
+++ b/GenerarMensajes.py
@@ -78,6 +78,7 @@ def abrir_generar_mensajes(db):
                 cmb_tipo["values"] = tipos
         except Exception as e:
             messagebox.showerror("Error", f"No se pudieron cargar los tipos: {e}")
+            print(f"❌ Error cargando tipos: {e}")
 
     def cargar_mensajes_por_tipo(event=None):
         tipo = cmb_tipo.get().strip()
@@ -91,6 +92,7 @@ def abrir_generar_mensajes(db):
             cmb_mensaje.set(mensajes[0] if mensajes else "")
         except Exception as e:
             messagebox.showerror("Error", f"No se pudieron cargar los mensajes: {e}")
+            print(f"❌ Error cargando mensajes del tipo {tipo}: {e}")
 
     cmb_tipo.bind("<<ComboboxSelected>>", cargar_mensajes_por_tipo)
 
@@ -122,6 +124,9 @@ def abrir_generar_mensajes(db):
             return
         hora = f"{h:02d}:{m:02d}"
         fechaHora = datetime(dia_date.year, dia_date.month, dia_date.day, h, m, 0)
+        if fechaHora < datetime.now():
+            messagebox.showerror("Error", "La fecha y hora no pueden estar en el pasado")
+            return
 
         payload = {
             "estado": "Pendiente",
@@ -137,9 +142,11 @@ def abrir_generar_mensajes(db):
         try:
             db.collection("Mensajes").document().set(payload, merge=True)
             messagebox.showinfo("OK", "Mensaje guardado")
+            print(f"✅ Mensaje guardado con fechaHora {fechaHora}")
             ventana_generar.destroy()
         except Exception as e:
             messagebox.showerror("Error", f"No se pudo guardar el mensaje: {e}")
+            print(f"❌ Error guardando mensaje: {e}")
         finally:
             btn_guardar.config(state="normal")
 

--- a/main.py
+++ b/main.py
@@ -19,6 +19,11 @@ from decimal import Decimal
 from typing import Optional
 from google.cloud.firestore_v1.base_query import FieldFilter
 
+try:
+    import tkcalendar  # noqa: F401
+except Exception:
+    print("⚠️ Instale tkcalendar para habilitar selectores de fecha: pip install tkcalendar")
+
 
 def _safe_str(v) -> Optional[str]:
     if v is None:


### PR DESCRIPTION
## Summary
- expand message management table to display type, schedule, uid and more
- include new fields in CSV export and enforce 200-char bodies with future date check
- warn if tkcalendar is missing for date selectors

## Testing
- `python -m py_compile SansebasSms_Sync/GenerarMensajes.py SansebasSms_Sync/GestionMensajes.py SansebasSms_Sync/main.py`
- `python SansebasSms_Sync/main.py` *(fails: ModuleNotFoundError: No module named 'firebase_admin')*
- `python GestionMensajes.py` *(fails: ModuleNotFoundError: No module named 'firebase_admin')*

------
https://chatgpt.com/codex/tasks/task_b_68b70cae0b84832781b6913b6a4826af