### PR TITLE
Improve message resend selection tracking and presets

### DIFF
--- a/GenerarMensajes.py
+++ b/GenerarMensajes.py
@@ -54,16 +54,14 @@ def abrir_generar_mensajes(db, preset=None):
     # --- Hora ---
     ttk.Label(frm, text="Hora:").grid(row=2, column=0, sticky="w", **pad)
     frm_time = ttk.Frame(frm)
+    sp_hora = ttk.Spinbox(frm_time, from_=0, to=23, width=3, state="readonly")
+    ttk.Label(frm_time, text=":").grid(row=0, column=1, padx=2)
+    sp_min = ttk.Spinbox(frm_time, from_=0, to=59, width=3, state="readonly")
+    sp_hora.grid(row=0, column=0)
+    sp_min.grid(row=0, column=2)
+    sp_hora.set("07")
+    sp_min.set("00")
     frm_time.grid(row=2, column=1, sticky="w", **pad)
-    hora_var = tk.StringVar(value="07")
-    min_var = tk.StringVar(value="00")
-    sp_hora = tk.Spinbox(frm_time, from_=0, to=23, width=3, textvariable=hora_var,
-                         state="readonly", wrap=True, format="%02.0f")
-    sp_hora.pack(side="left")
-    ttk.Label(frm_time, text=":").pack(side="left")
-    sp_min = tk.Spinbox(frm_time, from_=0, to=59, width=3, textvariable=min_var,
-                        state="readonly", wrap=True, format="%02.0f")
-    sp_min.pack(side="left")
 
     # --- Mensaje ---
     ttk.Label(frm, text="Mensaje:").grid(row=3, column=0, sticky="w", **pad)
@@ -145,8 +143,8 @@ def abrir_generar_mensajes(db, preset=None):
         if preset.get("hora"):
             try:
                 h, m = preset["hora"].split(":")
-                hora_var.set(h)
-                min_var.set(m)
+                sp_hora.set(h)
+                sp_min.set(m)
             except Exception:
                 pass
         if preset.get("cuerpo"):

--- a/GestionMensajes.py
+++ b/GestionMensajes.py
@@ -171,10 +171,11 @@ def abrir_gestion_mensajes(db: firestore.Client) -> None:
         "Estado",
         "Motivo",
         "Nombre",
+        "doc_id",
     ]
     tree = ttk.Treeview(frame_tree, columns=columnas, show="headings")
     for col in columnas:
-        tree.heading(col, text=col)
+        tree.heading(col, text=col if col != "doc_id" else "")
     tree.column("✓", width=30, anchor="center")
     tree.column("Tipo", width=80, anchor="w")
     tree.column("Día", width=80, anchor="w")
@@ -187,6 +188,7 @@ def abrir_gestion_mensajes(db: firestore.Client) -> None:
     tree.column("Estado", width=80, anchor="w")
     tree.column("Motivo", width=120, anchor="w")
     tree.column("Nombre", width=150, anchor="w")
+    tree.column("doc_id", width=0, stretch=False)
 
     vsb = ttk.Scrollbar(frame_tree, orient="vertical", command=tree.yview)
     hsb = ttk.Scrollbar(frame_tree, orient="horizontal", command=tree.xview)
@@ -219,7 +221,8 @@ def abrir_gestion_mensajes(db: firestore.Client) -> None:
 
     def refrescar_checkboxes():
         for iid in tree.get_children():
-            tree.set(iid, "✓", checkbox_imgs[iid in seleccionados])
+            doc_id = tree.set(iid, "doc_id") or iid
+            tree.set(iid, "✓", checkbox_imgs[doc_id in seleccionados])
 
     updating_select_all = False
 
@@ -247,11 +250,12 @@ def abrir_gestion_mensajes(db: firestore.Client) -> None:
         if col == "#1":
             item = tree.identify_row(event.y)
             if item:
-                if item in seleccionados:
-                    seleccionados.remove(item)
+                doc_id = tree.set(item, "doc_id") or item
+                if doc_id in seleccionados:
+                    seleccionados.remove(doc_id)
                 else:
-                    seleccionados.add(item)
-                tree.set(item, "✓", checkbox_imgs[item in seleccionados])
+                    seleccionados.add(doc_id)
+                tree.set(item, "✓", checkbox_imgs[doc_id in seleccionados])
                 actualizar_contador()
                 sync_select_all()
             return "break"
@@ -299,6 +303,7 @@ def abrir_gestion_mensajes(db: firestore.Client) -> None:
                     d.get("estado", ""),
                     d.get("motivo", ""),
                     d.get("Nombre", ""),
+                    doc_id,
                 ),
             )
         sync_select_all()


### PR DESCRIPTION
## Summary
- Track message selections via hidden doc_id column in GestionMensajes
- Switch GenerarMensajes time picker to ttk.Spinbox and honor presets

## Testing
- `python -m py_compile GestionMensajes.py GenerarMensajes.py`


------
https://chatgpt.com/codex/tasks/task_b_68b721e75a248327a91ffac4de12ff8e