### PR TITLE
feat: reset message status when resending

### DIFF
--- a/GenerarMensajes.py
+++ b/GenerarMensajes.py
@@ -155,7 +155,6 @@ def abrir_generar_mensajes(db, preset=None):
                 payload = {
                     "uid": uid,
                     "telefono": telefono,
-                    "estado": "Pendiente",
                     "motivo": "Pendiente",
                     "tipo": tipo,
                     "mensaje": mensaje,
@@ -164,6 +163,8 @@ def abrir_generar_mensajes(db, preset=None):
                     "hora": hora_str,
                     "fechaHora": fechaHora,
                 }
+                # Aseguramos que todos los nuevos mensajes comiencen como Pendiente
+                payload["estado"] = "Pendiente"
                 db.collection("Mensajes").document(doc_id).set(payload, merge=True)
                 count += 1
                 ventana_generar.update_idletasks()


### PR DESCRIPTION
## Summary
- add helpers to reset message status and update dedupe file when resending
- mark selected messages as pending before recreating and drop local notification IDs
- ensure new messages created via generator start with estado `Pendiente`

## Testing
- `python -m py_compile GestionMensajes.py GenerarMensajes.py`


------
https://chatgpt.com/codex/tasks/task_b_68b72d9139148327a0a5a88cac6bc7d3