### PR TITLE
Oculta botón y amplía gestión de mensajes

### DIFF
--- a/main.py
+++ b/main.py
@@ -380,7 +380,17 @@ tk.Button(frame, text="📁 Seleccionar carpeta de destino", command=seleccionar
 tk.Button(frame, text="📥 Descargar todas las colecciones", command=descargar_todo, height=2, width=40).pack(pady=5)
 tk.Button(frame, text="📤 Subir archivo Excel a Firebase", command=subir_archivo, height=2, width=40).pack(pady=5)
 tk.Button(frame, text="📨 Revisar mensajes pendientes", command=revisar_mensajes, height=2, width=40).pack(pady=5)
-tk.Button(frame, text="📝 Crear mensajes automáticos", command=crear_mensajes_para_todos, height=2, width=40, bg="lightblue").pack(pady=5)
+
+btn_crear_auto = tk.Button(
+    frame,
+    text="📝 Crear mensajes automáticos",
+    command=crear_mensajes_para_todos,
+    height=2,
+    width=40,
+    bg="lightblue",
+)
+btn_crear_auto.pack(pady=5)
+btn_crear_auto.pack_forget()  # Botón ocultado a petición: "Crear mensajes automáticos"
 tk.Button(frame, text="📲 Enviar notificaciones push", command=enviar_notificaciones_push, height=2, width=40, bg="lightgreen").pack(pady=5)
 tk.Button(frame, text="👥 Gestionar Usuarios", command=lambda: abrir_gestion_usuarios(db), height=2, width=40, bg="lightyellow").pack(pady=5)
 tk.Button(frame, text="📜 Gestionar Mensajes", command=lambda: abrir_gestion_mensajes(db), height=2, width=40).pack(pady=5)


### PR DESCRIPTION
## Summary
- Oculta el botón "Crear mensajes automáticos" en la ventana principal dejando su lógica intacta
- Amplía y reestructura la ventana de Gestión de Mensajes con geometría mayor, grid expansivo y columnas más anchas con scrollbars

## Testing
- `python -m py_compile main.py GestionMensajes.py`

------
https://chatgpt.com/codex/tasks/task_b_68b7361a0c548327a35166ba56ca8d56