### PR TITLE
Corregir cierre del popup de filtros y estilos de encabezado filtrado

### DIFF
--- a/GestionUsuarios.py
+++ b/GestionUsuarios.py
@@ -1287,6 +1287,9 @@ def abrir_gestion_usuarios(db):
     _notify_reset_cb = __apply_reset_in_ui
 
     style = ttk.Style()
+    normal_heading_fg = style.lookup("Treeview.Heading", "foreground")
+    style.configure("Normal.Treeview.Heading", foreground=normal_heading_fg or "")
+    style.configure("Filtered.Treeview.Heading", foreground="#555555")
 
     def _row_height():
         h = style.lookup("Treeview", "rowheight")
@@ -1312,12 +1315,12 @@ def abrir_gestion_usuarios(db):
                 texto += " ▲"
             elif orden_actual.get(c) == "desc":
                 texto += " ▼"
-            color = "blue" if c in filtros_activos else ""
+            estilo = "Filtered.Treeview.Heading" if c in filtros_activos else "Normal.Treeview.Heading"
             tree.heading(
                 c,
                 text=texto,
                 command=lambda c=c: ordenar_columna(c),
-                foreground=color,
+                style=estilo,
             )
 
     def ordenar_columna(col):
@@ -1998,6 +2001,18 @@ def abrir_gestion_usuarios(db):
         botones = ttk.Frame(container)
         botones.grid(row=9, column=0, sticky="e", pady=(8, 0))
 
+        cerrando_popup = False
+
+        def _cerrar_popup_seguro():
+            nonlocal cerrando_popup, filtro_popup
+            if cerrando_popup:
+                return
+            cerrando_popup = True
+            if popup.winfo_exists():
+                popup.destroy()
+            if filtro_popup is popup:
+                filtro_popup = None
+
         def _aceptar():
             seleccionados = {val for val, var in valores_vars.items() if var.get()}
             filtro_condicion = _filtro_local()
@@ -2013,21 +2028,23 @@ def abrir_gestion_usuarios(db):
                 )
             else:
                 _set_active_filter(col, FilterState(selected_values=seleccionados))
-            aplicar_filtros()
-            _cerrar_popup_filtros()
+            try:
+                aplicar_filtros()
+            finally:
+                _cerrar_popup_seguro()
 
         def _cancelar():
-            _cerrar_popup_filtros()
+            _cerrar_popup_seguro()
 
         ttk.Button(botones, text="Aceptar", command=_aceptar).grid(row=0, column=0, padx=(0, 6))
         ttk.Button(botones, text="Cancelar", command=_cancelar).grid(row=0, column=1)
 
         def _cerrar_si_fuera():
             if popup.winfo_exists() and popup.focus_displayof() is None:
-                _cerrar_popup_filtros()
+                _cerrar_popup_seguro()
 
         popup.bind("<FocusOut>", lambda _e: popup.after(50, _cerrar_si_fuera))
-        popup.bind("<Escape>", lambda _e: _cerrar_popup_filtros())
+        popup.bind("<Escape>", lambda _e: _cerrar_popup_seguro())
         entrada_busqueda.focus_set()
 
 


### PR DESCRIPTION
### Motivation

- Evitar que el popup de filtros quede bloqueado por manejadores `FocusOut` u otros al aceptar, cerrándolo de forma explícita y segura. 
- Mostrar visualmente qué columnas tienen un filtro activo aplicando un tono gris oscuro al encabezado sin usar `foreground` en `tree.heading`. 
- Mantener la coexistencia con la ordenación (▲/▼), múltiples filtros y limpieza de filtros. 
- Mantener la coherencia del código y no duplicar lógica existente.

### Description

- Se añadieron dos estilos `ttk`: `Normal.Treeview.Heading` y `Filtered.Treeview.Heading` y se configuran (`Filtered.Treeview.Heading` usa `#555555`) para marcar encabezados filtrados. 
- ` _actualizar_encabezados()` ahora aplica dinámicamente `style` por columna (`Filtered.Treeview.Heading` si la columna está en `filtros_activos`, en caso contrario `Normal.Treeview.Heading`) y preserva los indicadores de orden. 
- Se introdujo la función de cierre seguro `_cerrar_popup_seguro()` con bandera `cerrando_popup` para evitar reentradas y limpiar `filtro_popup`, y se usa en los botones `Aceptar`/`Cancelar`, en el manejador `Escape` y en el `FocusOut` diferido. 
- La acción de `Aceptar` ejecuta `aplicar_filtros()` dentro de un `try/finally` y siempre invoca el cierre seguro para garantizar que el popup no quede bloqueado.

### Testing

- No se ejecutaron pruebas automáticas sobre el cambio modificado. 
- Se verificó localmente que el archivo fue actualizado y se confirmó el commit.
- No se reportaron errores de sintaxis tras los cambios en la edición del archivo.
- No se ejecutaron suites de integración ni unitarias automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696172362b348327b601a4c5ab951ac4)