### PR TITLE
Marcar columnas filtradas en los encabezados con un prefijo visual

### DIFF
--- a/GestionUsuarios.py
+++ b/GestionUsuarios.py
@@ -1311,16 +1311,16 @@ def abrir_gestion_usuarios(db):
     def _actualizar_encabezados():
         for c in columnas:
             texto = encabezados.get(c, c)
+            if c in filtros_activos:
+                texto = f"■ {texto}"
             if orden_actual.get(c) == "asc":
                 texto += " ▲"
             elif orden_actual.get(c) == "desc":
                 texto += " ▼"
-            estilo = "Filtered.Treeview.Heading" if c in filtros_activos else "Normal.Treeview.Heading"
             tree.heading(
                 c,
                 text=texto,
                 command=lambda c=c: ordenar_columna(c),
-                style=estilo,
             )
 
     def ordenar_columna(col):


### PR DESCRIPTION
### Motivation
- Indicar visualmente qué columnas tienen filtros activos sin alterar filas ni celdas.
- Evitar crear o usar estilos `ttk` adicionales ni cambiar `foreground` en encabezados.
- Mantener los indicadores de orden (`▲` / `▼`) y combinarlos correctamente con la marca de filtro.
- Limitar la modificación únicamente a la función ` _actualizar_encabezados()` para minimizar el alcance del cambio.

### Description
- Se modificó solo la función ` _actualizar_encabezados()` en `GestionUsuarios.py` para actualizar el texto del encabezado por columna.
- Si una columna está en `filtros_activos` se antepone el prefijo `■ ` al texto base del encabezado.
- Se preservan los indicadores de orden añadiendo ` ▲` o ` ▼` según el valor en `orden_actual`.
- Se eliminó el intercambio de estilos de encabezado; ahora la señalización se realiza exclusivamente mediante el texto mostrado.

### Testing
- No se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6961745e41f48327a2c79aec04011513)